### PR TITLE
bug(Pagefind): Fix Searchbar on Vercel Linux-64 Build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/react": "^3.6.0",
         "@astrojs/starlight": "^0.24.5",
         "@astrojs/ts-plugin": "^1.8.0",
+        "@pagefind/linux-x64": "^1.1.0",
         "astro": "^4.11.4",
         "ethers": "^6.13.1",
         "react-toastify": "^10.0.5",
@@ -2012,6 +2013,17 @@
     "node_modules/@pagefind/default-ui": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.1.0.tgz",
+      "integrity": "sha512-4lsg6VB7A6PWTwaP8oSmXV4O9H0IHX7AlwTDcfyT+YJo/sPXOVjqycD5cdBgqNLfUk8B9bkWcTDCRmJbHrKeCw==",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.18.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@astrojs/react": "^3.6.0",
     "@astrojs/starlight": "^0.24.5",
     "@astrojs/ts-plugin": "^1.8.0",
+    "@pagefind/linux-x64": "^1.1.0",
     "astro": "^4.11.4",
     "ethers": "^6.13.1",
     "react-toastify": "^10.0.5",


### PR DESCRIPTION
Vercel uses linux-64 under the hood but the pagefind npm package that Starlight is using for some reason is not pulling in the linux build. This explicitly adds it as an override so that searching works on the docs