### PR TITLE
Add migration to a new server guide

### DIFF
--- a/redirects/spaceDocsRedirects.mjs
+++ b/redirects/spaceDocsRedirects.mjs
@@ -1,184 +1,236 @@
 export default {
-	'/learn/about-skale-network': '/welcome/intro-to-skale',
-	'/learn/faq': '/welcome/intro-to-skale',
-	'/learn/skale-chain-overview': '/welcome/intro-to-skale',
-	'/learn/hub-chain': '/building-applications/pick-a-chain',
-	'/learn/app-chain': '/run-a-skale-chain/intro-to-schains',
-	'/learn/calypso': '/welcome/chain-info',
-	'/learn/europa': '/welcome/chain-info', 
-	'/learn/nebula': '/welcome/chain-info',
-	'/learn/titan': '/welcome/chain-info',
-	'/learn/mainnet-beta': '/how-skale-works/mainnet-beta',
+	"/learn/about-skale-network": "/welcome/intro-to-skale",
+	"/learn/faq": "/welcome/intro-to-skale",
+	"/learn/skale-chain-overview": "/welcome/intro-to-skale",
+	"/learn/hub-chain": "/building-applications/pick-a-chain",
+	"/learn/app-chain": "/run-a-skale-chain/intro-to-schains",
+	"/learn/calypso": "/welcome/chain-info",
+	"/learn/europa": "/welcome/chain-info",
+	"/learn/nebula": "/welcome/chain-info",
+	"/learn/titan": "/welcome/chain-info",
+	"/learn/mainnet-beta": "/how-skale-works/mainnet-beta",
 
 	// Learn Advanced → How SKALE Works
-	'/learn/advanced/block-rotation': '/how-skale-works/block-rotation',
-	'/learn/advanced/consensus': '/how-skale-works/consensus',
-	'/learn/advanced/consensus-deep-dive': '/how-skale-works/consensus',
-	'/learn/advanced/ddos-protection': '/how-skale-works/ddos-protection',
-	'/learn/advanced/dkg-bls': '/how-skale-works/dkg-with-bls',
-	'/learn/advanced/precompiled-contracts': '/how-skale-works/precompiled-contracts',
-	'/learn/advanced/snapshots': '/how-skale-works/snapshots',
-	'/learn/advanced/topics/elliptic-curve-cryptography': '/how-skale-works/elliptic-curve-cryptography',
-	'/learn/advanced/topics/threshold-schemes': '/how-skale-works/threshold-schemes',
+	"/learn/advanced/block-rotation": "/how-skale-works/block-rotation",
+	"/learn/advanced/consensus": "/how-skale-works/consensus",
+	"/learn/advanced/consensus-deep-dive": "/how-skale-works/consensus",
+	"/learn/advanced/ddos-protection": "/how-skale-works/ddos-protection",
+	"/learn/advanced/dkg-bls": "/how-skale-works/dkg-with-bls",
+	"/learn/advanced/precompiled-contracts":
+		"/how-skale-works/precompiled-contracts",
+	"/learn/advanced/snapshots": "/how-skale-works/snapshots",
+	"/learn/advanced/topics/elliptic-curve-cryptography":
+		"/how-skale-works/elliptic-curve-cryptography",
+	"/learn/advanced/topics/threshold-schemes":
+		"/how-skale-works/threshold-schemes",
 
-	// Quick Start → Building Applications  
-	'/quick-start': '/welcome/get-started',
-	'/quick-start/': '/welcome/get-started',
-	'/quick-start/building-for-skale': '/building-applications/build-a-dapp',
-	'/quick-start/building-for-skale/': '/building-applications/build-a-dapp',
-	'/quick-start/deploy-to-testnet': '/building-applications/deploy-on-skale',
-	'/quick-start/deploy-to-testnet/': '/building-applications/deploy-on-skale',
-	'/quick-start/go-live': '/building-applications/deploy-on-skale',
-	'/quick-start/go-live/': '/building-applications/deploy-on-skale',
+	// Quick Start → Building Applications
+	"/quick-start": "/welcome/get-started",
+	"/quick-start/": "/welcome/get-started",
+	"/quick-start/building-for-skale": "/building-applications/build-a-dapp",
+	"/quick-start/building-for-skale/": "/building-applications/build-a-dapp",
+	"/quick-start/deploy-to-testnet": "/building-applications/deploy-on-skale",
+	"/quick-start/deploy-to-testnet/": "/building-applications/deploy-on-skale",
+	"/quick-start/go-live": "/building-applications/deploy-on-skale",
+	"/quick-start/go-live/": "/building-applications/deploy-on-skale",
 
 	// Builders App Developers → Building Applications
-	'/builders/app-developers/overview': '/building-applications/build-a-dapp',
-	'/builders/app-developers/evm-compatibility': '/building-applications/skale-vs-ethereum',
-	'/builders/app-developers/sfuel-distribution': '/building-applications/gas-fees',
-	'/builders/app-developers/sfuel-distribution/api-distribution': '/building-applications/gas-fees',
-	'/builders/app-developers/sfuel-distribution/contract-distribution': '/building-applications/gas-fees',
-	'/builders/app-developers/sfuel-distribution/pow-distribution': '/building-applications/gas-fees',
-	'/builders/app-developers/sfuel-station': '/faucet',
-	'/builders/developer-faq': '/building-applications/troubleshooting',
+	"/builders/app-developers/overview": "/building-applications/build-a-dapp",
+	"/builders/app-developers/evm-compatibility":
+		"/building-applications/skale-vs-ethereum",
+	"/builders/app-developers/sfuel-distribution":
+		"/building-applications/gas-fees",
+	"/builders/app-developers/sfuel-distribution/api-distribution":
+		"/building-applications/gas-fees",
+	"/builders/app-developers/sfuel-distribution/contract-distribution":
+		"/building-applications/gas-fees",
+	"/builders/app-developers/sfuel-distribution/pow-distribution":
+		"/building-applications/gas-fees",
+	"/builders/app-developers/sfuel-station": "/faucet",
+	"/builders/developer-faq": "/building-applications/troubleshooting",
 
 	// Builders CEX Integration → Building Applications
-	'/builders/cex-integration-guide': '/building-applications/cex-integration',
+	"/builders/cex-integration-guide": "/building-applications/cex-integration",
 
 	// Builders Chain Operators → Run a SKALE Chain
-	'/builders/chain-operators/overview': '/run-a-skale-chain/intro-to-schains',
-	'/builders/chain-operators/access-control': '/run-a-skale-chain/access-control',
-	'/builders/chain-operators/administrative-contracts': '/run-a-skale-chain/customize-schain',
-	'/builders/chain-operators/architecture': '/run-a-skale-chain/intro-to-schains',
-	'/builders/chain-operators/skale-chain-wallet': '/run-a-skale-chain/using-safe',
-	'/builders/chain-operators/submit-metadata': '/run-a-skale-chain/customize-schain',
+	"/builders/chain-operators/overview": "/run-a-skale-chain/intro-to-schains",
+	"/builders/chain-operators/access-control":
+		"/run-a-skale-chain/access-control",
+	"/builders/chain-operators/administrative-contracts":
+		"/run-a-skale-chain/customize-schain",
+	"/builders/chain-operators/architecture":
+		"/run-a-skale-chain/intro-to-schains",
+	"/builders/chain-operators/skale-chain-wallet":
+		"/run-a-skale-chain/using-safe",
+	"/builders/chain-operators/submit-metadata":
+		"/run-a-skale-chain/customize-schain",
 
 	// Builders Node Operators → Run a SKALE Node
-	'/builders/node-operators/overview': '/run-a-skale-node/overview',
-	'/builders/node-operators/skale-nodes': '/run-a-skale-node/run-supernode',
-	'/builders/node-operators/archive-node': '/run-a-skale-node/run-archive-node',
-	'/builders/node-operators/archive-node/': '/run-a-skale-node/run-archive-node',
-	'/builders/node-operators/full-sync-node': '/run-a-skale-node/run-sync-node',
-	'/builders/node-operators/skale-proxy': '/run-a-skale-node/overview',
+	"/builders/node-operators/overview": "/run-a-skale-node/overview",
+	"/builders/node-operators/skale-nodes": "/run-a-skale-node/run-supernode",
+	"/builders/node-operators/skale-nodes":
+		"/run-a-skale-node/migrate-node-with-sgxwallet",
+	"/builders/node-operators/archive-node":
+		"/run-a-skale-node/run-archive-node",
+	"/builders/node-operators/archive-node/":
+		"/run-a-skale-node/run-archive-node",
+	"/builders/node-operators/full-sync-node":
+		"/run-a-skale-node/run-sync-node",
+	"/builders/node-operators/skale-proxy": "/run-a-skale-node/overview",
 
 	// Ecosystem Validators → Run a SKALE Node
-	'/ecosystem/validators/overview': '/run-a-skale-node/overview',
-	'/ecosystem/validators/compliance-requirements': '/run-a-skale-node/compliance-requirements',
-	'/ecosystem/validators/faq': '/run-a-skale-node/faq',
-	'/ecosystem/validators/troubleshooting': '/run-a-skale-node/troubleshooting',
-	'/ecosystem/validators/swap-limit-fix': '/run-a-skale-node/swap-limit-fix',
-	'/ecosystem/validators/validator-setup': '/run-a-skale-node/overview',
+	"/ecosystem/validators/overview": "/run-a-skale-node/overview",
+	"/ecosystem/validators/compliance-requirements":
+		"/run-a-skale-node/compliance-requirements",
+	"/ecosystem/validators/faq": "/run-a-skale-node/faq",
+	"/ecosystem/validators/troubleshooting":
+		"/run-a-skale-node/troubleshooting",
+	"/ecosystem/validators/swap-limit-fix": "/run-a-skale-node/swap-limit-fix",
+	"/ecosystem/validators/validator-setup": "/run-a-skale-node/overview",
 
 	// Ecosystem Validators Node CLI → Run a SKALE Node
-	'/ecosystem/validators/node-cli/overview': '/run-a-skale-node/node-cli/overview',
-	'/ecosystem/validators/node-cli/changing-node-ip': '/run-a-skale-node/node-cli/changing-node-ip',
-	'/ecosystem/validators/node-cli/node-ssl-setup': '/run-a-skale-node/node-cli/node-ssl-setup',
-	'/ecosystem/validators/node-cli/releases/v2-0': '/run-a-skale-node/node-cli/releases/v2-0',
+	"/ecosystem/validators/node-cli/overview":
+		"/run-a-skale-node/node-cli/overview",
+	"/ecosystem/validators/node-cli/changing-node-ip":
+		"/run-a-skale-node/node-cli/changing-node-ip",
+	"/ecosystem/validators/node-cli/node-ssl-setup":
+		"/run-a-skale-node/node-cli/node-ssl-setup",
+	"/ecosystem/validators/node-cli/releases/v2-0":
+		"/run-a-skale-node/node-cli/releases/v2-0",
 
 	// Ecosystem Validators Releases → Run a SKALE Node
-	'/ecosystem/validators/releases/3-0-2-upgrade': '/run-a-skale-node/releases/3-0-3-upgrade',
-	'/ecosystem/validators/releases/3-0-3-upgrade': '/run-a-skale-node/releases/3-0-3-upgrade',
-	'/ecosystem/validators/releases/3-1-0-upgrade': '/run-a-skale-node/releases/3-1-0-upgrade',
-	'/ecosystem/validators/releases/3-1-1-upgrade': '/run-a-skale-node/releases/3-1-1-upgrade',
-	'/ecosystem/validators/releases/3-1-1-upgrade-local-sgx': '/run-a-skale-node/releases/3-1-1-upgrade-local-sgx',
+	"/ecosystem/validators/releases/3-0-2-upgrade":
+		"/run-a-skale-node/releases/3-0-3-upgrade",
+	"/ecosystem/validators/releases/3-0-3-upgrade":
+		"/run-a-skale-node/releases/3-0-3-upgrade",
+	"/ecosystem/validators/releases/3-1-0-upgrade":
+		"/run-a-skale-node/releases/3-1-0-upgrade",
+	"/ecosystem/validators/releases/3-1-1-upgrade":
+		"/run-a-skale-node/releases/3-1-1-upgrade",
+	"/ecosystem/validators/releases/3-1-1-upgrade-local-sgx":
+		"/run-a-skale-node/releases/3-1-1-upgrade-local-sgx",
 
 	// Ecosystem Validators CLI → Run a SKALE Node
-	'/ecosystem/validators/validator-cli': '/run-a-skale-node/validator-cli/overview',
-	'/ecosystem/validators/validator-cli/overview': '/run-a-skale-node/validator-cli/overview',
-	'/ecosystem/validators/validator-cli/releases/v1-2-0': '/run-a-skale-node/validator-cli/releases/v1-2-0',
-	'/ecosystem/validators/validator-cli/self-recharding-wallets': '/run-a-skale-node/validator-cli/self-recharging-wallets',
-	'/ecosystem/validators/validator-cli/self-recharging-wallets': '/run-a-skale-node/validator-cli/self-recharging-wallets',
+	"/ecosystem/validators/validator-cli":
+		"/run-a-skale-node/validator-cli/overview",
+	"/ecosystem/validators/validator-cli/overview":
+		"/run-a-skale-node/validator-cli/overview",
+	"/ecosystem/validators/validator-cli/releases/v1-2-0":
+		"/run-a-skale-node/validator-cli/releases/v1-2-0",
+	"/ecosystem/validators/validator-cli/self-recharding-wallets":
+		"/run-a-skale-node/validator-cli/self-recharging-wallets",
+	"/ecosystem/validators/validator-cli/self-recharging-wallets":
+		"/run-a-skale-node/validator-cli/self-recharging-wallets",
 
 	// Ecosystem Validators Watchdog → Run a SKALE Node
-	'/ecosystem/validators/watchdog/overview': '/run-a-skale-node/watchdog/overview',
-	'/ecosystem/validators/watchdog/apis': '/run-a-skale-node/watchdog/apis',
+	"/ecosystem/validators/watchdog/overview":
+		"/run-a-skale-node/watchdog/overview",
+	"/ecosystem/validators/watchdog/apis": "/run-a-skale-node/watchdog/apis",
 
 	// Ecosystem Governance/Delegators → Welcome
-	'/ecosystem/delegators/overview': '/welcome/intro-to-skale',
-	'/ecosystem/governance/overview': '/how-skale-works/skl-token',
+	"/ecosystem/delegators/overview": "/welcome/intro-to-skale",
+	"/ecosystem/governance/overview": "/how-skale-works/skl-token",
 
 	// Validators CLI (Legacy) → Run a SKALE Node
-	'/validators/validator-cli': '/run-a-skale-node/validator-cli/overview',
+	"/validators/validator-cli": "/run-a-skale-node/validator-cli/overview",
 
 	// ==========================================
 	// TOOLS & BUILDERS GENERAL REDIRECTS
 	// ==========================================
 
 	// General section redirects
-	'/builders': '/building-applications/build-a-dapp',
-	'/tools': '/building-applications/build-a-dapp',
-	'/ecosystem': '/welcome/get-started',
+	"/builders": "/building-applications/build-a-dapp",
+	"/tools": "/building-applications/build-a-dapp",
+	"/ecosystem": "/welcome/get-started",
 
 	// Tool category redirects
-	'/builders/tools/all-in-one': '/building-applications/build-a-dapp',
-	'/builders/tools/all-in-one/crossmint': '/building-applications/build-a-dapp',
-	'/builders/tools/all-in-one/sequence': '/building-applications/build-a-dapp',
-	'/builders/tools/all-in-one/thirdweb': '/building-applications/build-a-dapp',
+	"/builders/tools/all-in-one": "/building-applications/build-a-dapp",
+	"/builders/tools/all-in-one/crossmint":
+		"/building-applications/build-a-dapp",
+	"/builders/tools/all-in-one/sequence":
+		"/building-applications/build-a-dapp",
+	"/builders/tools/all-in-one/thirdweb":
+		"/building-applications/build-a-dapp",
 
-	'/builders/tools/bridges': '/skale-bridge/overview',
-	'/builders/tools/bridges/layer-zero': '/skale-bridge/overview',
-	'/builders/tools/bridges/meson-fi': '/skale-bridge/overview',
-	'/builders/tools/bridges/skale-native-bridge': '/skale-bridge/overview',
+	"/builders/tools/bridges": "/skale-bridge/overview",
+	"/builders/tools/bridges/layer-zero": "/skale-bridge/overview",
+	"/builders/tools/bridges/meson-fi": "/skale-bridge/overview",
+	"/builders/tools/bridges/skale-native-bridge": "/skale-bridge/overview",
 
-	'/builders/tools/contracts': '/building-applications/solidity-quickstart',
-	'/builders/tools/contracts/hardhat': '/building-applications/solidity-quickstart',
-	'/builders/tools/contracts/multicall': '/building-applications/solidity-quickstart',
-	'/builders/tools/contracts/openzeppelin': '/building-applications/solidity-quickstart',
-	'/builders/tools/contracts/remix': '/building-applications/solidity-quickstart',
+	"/builders/tools/contracts": "/building-applications/solidity-quickstart",
+	"/builders/tools/contracts/hardhat":
+		"/building-applications/solidity-quickstart",
+	"/builders/tools/contracts/multicall":
+		"/building-applications/solidity-quickstart",
+	"/builders/tools/contracts/openzeppelin":
+		"/building-applications/solidity-quickstart",
+	"/builders/tools/contracts/remix":
+		"/building-applications/solidity-quickstart",
 
-	'/builders/tools/data': '/building-applications/build-a-dapp',
-	'/builders/tools/data/dune': '/building-applications/build-a-dapp',
-	'/builders/tools/data/goldsky': '/building-applications/build-a-dapp',
-	'/builders/tools/data/subsquid': '/building-applications/build-a-dapp',
-	'/builders/tools/data/the-graph': '/building-applications/build-a-dapp',
+	"/builders/tools/data": "/building-applications/build-a-dapp",
+	"/builders/tools/data/dune": "/building-applications/build-a-dapp",
+	"/builders/tools/data/goldsky": "/building-applications/build-a-dapp",
+	"/builders/tools/data/subsquid": "/building-applications/build-a-dapp",
+	"/builders/tools/data/the-graph": "/building-applications/build-a-dapp",
 
-	'/builders/tools/gaming': '/building-applications/pick-a-chain',
-	'/builders/tools/gaming/eidolon': '/building-applications/pick-a-chain',
-	'/builders/tools/gaming/emergence': '/building-applications/pick-a-chain',
-	'/builders/tools/gaming/mirage': '/building-applications/pick-a-chain',
-	'/builders/tools/gaming/web3unreal': '/building-applications/pick-a-chain',
+	"/builders/tools/gaming": "/building-applications/pick-a-chain",
+	"/builders/tools/gaming/eidolon": "/building-applications/pick-a-chain",
+	"/builders/tools/gaming/emergence": "/building-applications/pick-a-chain",
+	"/builders/tools/gaming/mirage": "/building-applications/pick-a-chain",
+	"/builders/tools/gaming/web3unreal": "/building-applications/pick-a-chain",
 
-	'/builders/tools/libraries': '/building-applications/build-a-dapp',
-	'/builders/tools/libraries/ethersv5': '/building-applications/build-a-dapp',
-	'/builders/tools/libraries/ethersv6': '/building-applications/build-a-dapp',
-	'/builders/tools/libraries/kethereum': '/building-applications/build-a-dapp',
-	'/builders/tools/libraries/nethereum': '/building-applications/build-a-dapp',
-	'/builders/tools/libraries/viem': '/building-applications/build-a-dapp',
-	'/builders/tools/libraries/web3dart': '/building-applications/build-a-dapp',
-	'/builders/tools/libraries/web3j': '/building-applications/build-a-dapp',
+	"/builders/tools/libraries": "/building-applications/build-a-dapp",
+	"/builders/tools/libraries/ethersv5": "/building-applications/build-a-dapp",
+	"/builders/tools/libraries/ethersv6": "/building-applications/build-a-dapp",
+	"/builders/tools/libraries/kethereum":
+		"/building-applications/build-a-dapp",
+	"/builders/tools/libraries/nethereum":
+		"/building-applications/build-a-dapp",
+	"/builders/tools/libraries/viem": "/building-applications/build-a-dapp",
+	"/builders/tools/libraries/web3dart": "/building-applications/build-a-dapp",
+	"/builders/tools/libraries/web3j": "/building-applications/build-a-dapp",
 
-	'/builders/tools/nfts': '/building-applications/build-a-dapp',
-	'/builders/tools/nfts/dripverse': '/building-applications/build-a-dapp',
-	'/builders/tools/nfts/keepsake': '/building-applications/build-a-dapp',
-	'/builders/tools/nfts/pixelrealm': '/building-applications/build-a-dapp',
-	'/builders/tools/nfts/reservoir': '/building-applications/build-a-dapp',
-	'/builders/tools/nfts/snag': '/building-applications/build-a-dapp',
+	"/builders/tools/nfts": "/building-applications/build-a-dapp",
+	"/builders/tools/nfts/dripverse": "/building-applications/build-a-dapp",
+	"/builders/tools/nfts/keepsake": "/building-applications/build-a-dapp",
+	"/builders/tools/nfts/pixelrealm": "/building-applications/build-a-dapp",
+	"/builders/tools/nfts/reservoir": "/building-applications/build-a-dapp",
+	"/builders/tools/nfts/snag": "/building-applications/build-a-dapp",
 
-	'/builders/tools/oracles': '/building-applications/random-number-generation',
-	'/builders/tools/oracles/razor': '/building-applications/random-number-generation',
-	'/builders/tools/oracles/skale-connect': '/building-applications/random-number-generation',
+	"/builders/tools/oracles":
+		"/building-applications/random-number-generation",
+	"/builders/tools/oracles/razor":
+		"/building-applications/random-number-generation",
+	"/builders/tools/oracles/skale-connect":
+		"/building-applications/random-number-generation",
 
-	'/builders/tools/payments': '/building-applications/payments-on-skale',
-	'/builders/tools/payments/transak': '/building-applications/payments-on-skale',
+	"/builders/tools/payments": "/building-applications/payments-on-skale",
+	"/builders/tools/payments/transak":
+		"/building-applications/payments-on-skale",
 
-	'/builders/tools/rng': '/building-applications/random-number-generation',
-	'/builders/tools/rng/': '/building-applications/random-number-generation',
-	'/builders/tools/rng/skale-rng': '/building-applications/random-number-generation',
+	"/builders/tools/rng": "/building-applications/random-number-generation",
+	"/builders/tools/rng/": "/building-applications/random-number-generation",
+	"/builders/tools/rng/skale-rng":
+		"/building-applications/random-number-generation",
 
-	'/builders/tools/wallets': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/coinbase': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/connectkit': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/dynamic-xyz': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/enkrypt': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/invisible-signer': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/ledger': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/magic': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/metakeep': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/metamask': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/moon': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/portis': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/privy': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/rainbowkit': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/trezor': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/wallet-connect': '/building-applications/build-a-dapp',
-	'/builders/tools/wallets/web3auth': '/building-applications/build-a-dapp',
-}
+	"/builders/tools/wallets": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/coinbase": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/connectkit": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/dynamic-xyz":
+		"/building-applications/build-a-dapp",
+	"/builders/tools/wallets/enkrypt": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/invisible-signer":
+		"/building-applications/build-a-dapp",
+	"/builders/tools/wallets/ledger": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/magic": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/metakeep": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/metamask": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/moon": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/portis": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/privy": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/rainbowkit": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/trezor": "/building-applications/build-a-dapp",
+	"/builders/tools/wallets/wallet-connect":
+		"/building-applications/build-a-dapp",
+	"/builders/tools/wallets/web3auth": "/building-applications/build-a-dapp",
+};

--- a/routes/run-a-skale-node.mjs
+++ b/routes/run-a-skale-node.mjs
@@ -1,71 +1,111 @@
 const successVariant = "success";
 
 export default [
-	{ "label": "Overview", "slug": "run-a-skale-node/overview" },
-	{ "label": "Run Supernode", "slug": "run-a-skale-node/run-supernode" },
-	{ "label": "Run Sync Node", "slug": "run-a-skale-node/run-sync-node" },
-	{ "label": "Run Archive Node", "slug": "run-a-skale-node/run-archive-node" },
-	{ "label": "Compliance Requirements", "slug": "run-a-skale-node/compliance-requirements" },
-	{ "label": "Swap Limit Fix", "slug": "run-a-skale-node/swap-limit-fix" },
-	{ "label": "FAQ", "slug": "run-a-skale-node/faq" },
-	{ "label": "Troubleshooting", "slug": "run-a-skale-node/troubleshooting" },
+	{ label: "Overview", slug: "run-a-skale-node/overview" },
+	{ label: "Run Supernode", slug: "run-a-skale-node/run-supernode" },
 	{
-		"label": "Node CLI",
-		"collapsed": true,
-		"items": [
-			{ "label": "Intro to Node CLI", "slug": "run-a-skale-node/node-cli/overview" },
-			{ "label": "Changing Node IP", "slug": "run-a-skale-node/node-cli/changing-node-ip" },
-			{ "label": "Node SSL Setup", "slug": "run-a-skale-node/node-cli/node-ssl-setup" },
-			{
-				"label": "v2.0",
-				"slug": "run-a-skale-node/node-cli/releases/v2-0",
-				"badge": {
-					"text": "Latest Release",
-					"variant": successVariant
-				}
-			}
-		]
+		label: "Migrate Supernode",
+		slug: "run-a-skale-node/migrate-node-with-sgxwallet",
 	},
+	{ label: "Run Sync Node", slug: "run-a-skale-node/run-sync-node" },
+	{ label: "Run Archive Node", slug: "run-a-skale-node/run-archive-node" },
 	{
-		"label": "Validator CLI",
-		"collapsed": true,
-		"items": [
-			{ "label": "Intro to Validator CLI", "slug": "run-a-skale-node/validator-cli/overview" },
-			{ "label": "Self Recharging Wallets", "slug": "run-a-skale-node/validator-cli/self-recharging-wallets" },
-			{
-				"label": "v1.2.0",
-				"slug": "run-a-skale-node/validator-cli/releases/v1-2-0",
-				"badge": {
-					"text": "Latest Release",
-					"variant": successVariant
-				}
-			}
-		]
+		label: "Compliance Requirements",
+		slug: "run-a-skale-node/compliance-requirements",
 	},
+	{ label: "Swap Limit Fix", slug: "run-a-skale-node/swap-limit-fix" },
+	{ label: "FAQ", slug: "run-a-skale-node/faq" },
+	{ label: "Troubleshooting", slug: "run-a-skale-node/troubleshooting" },
 	{
-		"label": "Watchdog",
-		"collapsed": true,
-		"items": [
-			{ "label": "Intro to Watchdog", "slug": "run-a-skale-node/watchdog/overview" }
-		]
-	},
-	{
-		"label": "Network Releases",
-		"collapsed": true,
-		"items": [
+		label: "Node CLI",
+		collapsed: true,
+		items: [
 			{
-				"label": "4.0.1 Upgrade",
-				"slug": "run-a-skale-node/releases/4-0-1-upgrade",
-				"badge": {
-					"text": "Latest Release",
-					"variant": successVariant
-				}
+				label: "Intro to Node CLI",
+				slug: "run-a-skale-node/node-cli/overview",
 			},
-			{ "label": "4.0.0 Upgrade", "slug": "run-a-skale-node/releases/4-0-0-upgrade" },
-			{ "label": "3.1.1 Upgrade (Local SGX)", "slug": "run-a-skale-node/releases/3-1-1-upgrade-local-sgx" },
-			{ "label": "3.1.1 Upgrade", "slug": "run-a-skale-node/releases/3-1-1-upgrade" },
-			{ "label": "3.1.0 Upgrade", "slug": "run-a-skale-node/releases/3-1-0-upgrade" },
-			{ "label": "3.0.3 Upgrade", "slug": "run-a-skale-node/releases/3-0-3-upgrade" },
-		]
-	}
-]
+			{
+				label: "Changing Node IP",
+				slug: "run-a-skale-node/node-cli/changing-node-ip",
+			},
+			{
+				label: "Node SSL Setup",
+				slug: "run-a-skale-node/node-cli/node-ssl-setup",
+			},
+			{
+				label: "v2.0",
+				slug: "run-a-skale-node/node-cli/releases/v2-0",
+				badge: {
+					text: "Latest Release",
+					variant: successVariant,
+				},
+			},
+		],
+	},
+	{
+		label: "Validator CLI",
+		collapsed: true,
+		items: [
+			{
+				label: "Intro to Validator CLI",
+				slug: "run-a-skale-node/validator-cli/overview",
+			},
+			{
+				label: "Self Recharging Wallets",
+				slug: "run-a-skale-node/validator-cli/self-recharging-wallets",
+			},
+			{
+				label: "v1.2.0",
+				slug: "run-a-skale-node/validator-cli/releases/v1-2-0",
+				badge: {
+					text: "Latest Release",
+					variant: successVariant,
+				},
+			},
+		],
+	},
+	{
+		label: "Watchdog",
+		collapsed: true,
+		items: [
+			{
+				label: "Intro to Watchdog",
+				slug: "run-a-skale-node/watchdog/overview",
+			},
+		],
+	},
+	{
+		label: "Network Releases",
+		collapsed: true,
+		items: [
+			{
+				label: "4.0.1 Upgrade",
+				slug: "run-a-skale-node/releases/4-0-1-upgrade",
+				badge: {
+					text: "Latest Release",
+					variant: successVariant,
+				},
+			},
+			{
+				label: "4.0.0 Upgrade",
+				slug: "run-a-skale-node/releases/4-0-0-upgrade",
+			},
+			{
+				label: "3.1.1 Upgrade (Local SGX)",
+				slug: "run-a-skale-node/releases/3-1-1-upgrade-local-sgx",
+			},
+			{
+				label: "3.1.1 Upgrade",
+				slug: "run-a-skale-node/releases/3-1-1-upgrade",
+			},
+			{
+				label: "3.1.0 Upgrade",
+				slug: "run-a-skale-node/releases/3-1-0-upgrade",
+			},
+			{
+				label: "3.0.3 Upgrade",
+				slug: "run-a-skale-node/releases/3-0-3-upgrade",
+			},
+		],
+	},
+];

--- a/src/content/docs/run-a-skale-node/migrate-node-with-sgxwallet.mdx
+++ b/src/content/docs/run-a-skale-node/migrate-node-with-sgxwallet.mdx
@@ -1,0 +1,253 @@
+---
+title: Migrate SKALE Node with SGXWallet to New Server
+description: Step-by-step guide for migrating a SKALE node and SGXWallet to a new server
+---
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+This guide provides instructions for migrating a SKALE node and SGXWallet to a new server following the recommended migration process.
+
+## Prerequisites
+
+Before starting the migration, ensure you have:
+
+- Access to both the current and new servers
+- Administrative privileges on both systems
+- Secure network connection between servers
+
+   <Aside type="caution" title="Important">
+     Make sure backup is created before starting migration. You can use the `skale node backup .` command to create a backup of your current node and save `sgx_data` folder for SGX wallet as well as `sgxwallet_backup_key.txt`
+   </Aside>
+
+## Migration Steps
+
+
+### Migrate SGX
+
+<Steps>
+1. **Setup new server**
+
+   Prepare a new server with:
+   - Ubuntu 22.04 LTS (Jammy Jellyfish)
+   - SGX-enabled Intel processor
+   - 8 physical cores
+   - 16 GB RAM
+   - 200 GB disk mounted as /
+   - Swap size equals to half (1/2) of RAM size
+
+2. **Install packages required for the node**
+
+   ```bash
+   sudo apt-get update && sudo apt-get upgrade -y
+   sudo apt-get install -y docker.io docker-compose-plugin
+   sudo apt-get install -y build-essential make cmake gcc g++ yasm  python libprotobuf10 flex bison automake libtool texinfo libgcrypt20-dev libgnutls28-dev
+   sudo apt-get install -y docker
+   sudo apt-get install -y libelf-dev cpuid
+   ```
+
+3. **Verify your processor supports Intel SGX with:**
+
+   ```shell
+   cpuid | grep SGX:
+   ```
+
+   <Aside type="caution" title="Important">
+   After installing docker make sure that `live-restore` option
+   is enabled in `/etc/docker/daemon.json`. See more info in the [docker docs](https://docs.docker.com/config/containers/live-restore/).
+   </Aside>
+
+4. **Disable automatic updates**
+
+   It's recommended to only update the SGXWallet server if there are critical security fixes. This is because SGXWallet is based on low
+   level technology, and kernel updates may break the system. Currently SGX is tested on 5.15\* kernels. It's best to avoid minor version updates too.
+
+   To make sure `apt update` won't update the kernel you should use apt-mark hold command:
+
+   ```shell
+   sudo apt-mark hold linux-generic linux-image-generic linux-headers-generic
+   ```
+
+   Also if you configured unattended upgrades, you should make sure kernel won't update automatically. To do this, add the following lines to `/etc/apt/apt.conf.d/50unattended-upgrades` file:
+
+   ```shell
+   Unattended-Upgrade::Package-Blacklist {
+           "linux-generic";
+           "linux-image-generic";
+           "linux-headers-generic";
+   };
+   ```
+
+   **Output**
+
+   ```shell
+   SGX: Software Guard Extensions supported = true
+   ```
+
+5. Configure firewall between SGX and node servers
+
+
+6. Download SGXWallet source code
+
+   Clone SGX Wallet Repository to your machine:
+
+   ```shell
+   git clone https://github.com/skalenetwork/sgxwallet/
+   cd sgxwallet
+   git checkout stable
+   ```
+
+7. Enable SGX on the new server
+   **SGX Wallet repository includes the sgx_enable utility. To enable SGX run:**
+
+   ```shell
+   sudo ./sgx_enable
+   ```
+
+   **Install SGX driver:**
+
+   ```shell
+   cd scripts
+   sudo ./sgx_linux_x64_driver_2.11.b6f5b4a.bin
+   cd ..
+   ```
+
+   **System Reboot:**
+
+   <Aside type="note">
+   Reboot your machine after driver install!
+   </Aside>
+
+   **Check driver installation:**
+   To check that isgx device is properly installed run this command:
+
+   ```shell
+   ls /dev/isgx /dev/sg0
+   ```
+
+   If you don't see the isgx device, you need to troubleshoot your driver installation from [here](https://github.com/skalenetwork/sgxwallet/blob/develop/docs/enabling-sgx.md).
+
+8. **Copy sgx_data folder to the new server**
+
+   From your old server, securely transfer the SGX data:
+   ```bash
+   # On old server - create backup
+   tar -czf sgx_data_backup.tar.gz -C sgxwallet/run_sgx sgx_data
+
+   # Transfer to new server (use scp, rsync, or secure method)
+   scp sgx_data_backup.tar.gz user@new-server:/path/to/transfer/
+
+   # On new server - extract to correct location
+   cd sgxwallet/run_sgx
+   tar -xzf /path/to/transfer/sgx_data_backup.tar.gz
+   ```
+
+   <Aside type="caution" title="Important">
+   After uploading backup to the new server make sure that sgxwallet_backup_key.txt is stored in sgx_data
+   </Aside>
+
+
+9. **Set the version and -b flag in docker-compose.yml**
+   Edit the `sgxwallet/run_sgx/docker-compose.yml` file:
+
+   - Change the image version to: `skalenetwork/sgxwallet:1.9.0-stable.4`
+   - Add `-b` to the existing command section (don't replace the entire command, just add `-b` to it)
+
+
+10. **Run docker-compose up -d**
+
+      ```bash
+      cd sgxwallet/run_sgx
+      docker-compose up -d
+
+      # Verify SGXWallet is running
+      docker-compose ps
+      docker-compose logs
+      ```
+
+</Steps>
+
+### Migrate Node
+
+<Steps>
+1. **Setup new server**
+
+   Prepare a new server with:
+   - Ubuntu 22.04 LTS (Jammy Jellyfish)
+   - 8 physical cores
+   - 32 GB RAM
+   - 16 GB RAM
+   - 100 GB disk mounted as /
+   - 2Tb additional disk (not mounted)
+
+2. **Install packages required for the node**
+
+   ```bash
+   sudo apt-get update && sudo apt-get upgrade -y
+   sudo apt-get install -y docker.io docker-compose-plugin nftables
+   ```
+
+    <Aside type="caution" title="Important">
+    After installing docker make sure that `live-restore` option
+    is enabled in `/etc/docker/daemon.json`. See more info in the [docker docs](https://docs.docker.com/config/containers/live-restore/).
+    </Aside>
+
+3. **Disable automatic updates**
+
+   Currently SKALE Node is tested on 5.15\* kernels. It's best to avoid minor version updates too.
+
+   To make sure `apt update` won't update the kernel you should use apt-mark hold command:
+
+   ```shell
+   sudo apt-mark hold linux-generic linux-image-generic linux-headers-generic
+   ```
+
+   Also if you configured unattended upgrades, you should make sure kernel won't update automatically. To do this, add the following lines to `/etc/apt/apt.conf.d/50unattended-upgrades` file:
+
+   ```shell
+   Unattended-Upgrade::Package-Blacklist {
+           "linux-generic";
+           "linux-image-generic";
+           "linux-headers-generic";
+   };
+   ```
+
+4. **Run node backup on old server**
+
+   ```bash
+   # On old server
+   skale node backup .
+   ```
+
+   This will create a backup tarball (e.g., `skale-node-backup-YYYY-MM-DD-HHMMSS.tar.gz`)
+
+5. **Copy backup tarball and .env config to the new server**
+
+   ```bash
+   # Transfer backup and configuration files
+   scp skale-node-backup-*.tar.gz user@new-server:/path/to/new/location/
+   scp .env user@new-server:/path/to/new/location/
+   ```
+
+6. **Download node-CLI version**
+
+    ```bash
+    curl -L https://github.com/skalenetwork/node-cli/releases/download/2.6.2/skale-2.6.2-Linux-x86_64 > /usr/local/bin/skale
+    chmod +x /usr/local/bin/skale
+
+    # Verify installation
+    skale --version
+    ```
+
+7. **Restore node from backup**
+
+    ```bash
+    # Navigate to your working directory
+    cd backup tarball location
+
+    # Restore node using backup and environment file
+    skale node restore skale-node-backup-*.tar.gz .env
+    ```
+</Steps>
+
+<Aside type="tip">
+Keep the old server running until you've fully verified the new setup is working correctly. This allows for quick rollback if needed.
+</Aside>


### PR DESCRIPTION
This pull request updates the SKALE documentation redirects and navigation to improve clarity and coverage, especially for node operators and tooling sections. The main changes include reformatting the redirects for consistency, adding new routes for node migration, and ensuring all relevant tools and builder resources have proper redirects.

**Navigation and Route Updates:**

* Added a new "Migrate Supernode" route to the node operator navigation, making migration documentation easier to find.

**Redirects Consistency and Coverage:**

* Reformatted all entries in `spaceDocsRedirects.mjs` to use double quotes and consistent indentation for better readability and maintainability.
* Added redirects for all builder tools categories (all-in-one, bridges, contracts, data, gaming, libraries, nfts, oracles, payments, rng, wallets) to ensure users are routed to the correct documentation sections.
* Updated node operator redirects to include migration documentation and ensure all node types and CLI tools are covered.
* Ensured that legacy and ecosystem validator routes redirect to the updated node and validator documentation.